### PR TITLE
Fix Cargo.toml formatting error and refactor files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "rustywiki"
-version = "0.1.0 alpha"
+version = "0.0.1"
 authors = ["rustywiki team"]
 edition = "2018"
 
 [dependencies]
-actix-web = "2.0.0"
-actix-rt = "1.0"
+actix-web = "2"
+actix-rt = "1"
 actix-files = "0.2.1"
 actix-service = "1.0.5"
 listenfd = "0.3"
+env_logger = "0.7"

--- a/src/action/access_doc.rs
+++ b/src/action/access_doc.rs
@@ -1,25 +1,32 @@
-use actix_web::{get, post, put, delete};
+use actix_web::{
+    get,
+    post,
+    put,
+    delete,
+    Responder,
+    HttpRequest,
+};
 
 #[post("/api/create_doc")]
-async fn create_doc(_req: HttpRequest) -> impl Responder 
+async fn create_doc(_req: HttpRequest) -> impl Responder
 {
-    "미구현"
+    "unimplemented"
 }
 
 #[get("/api/read_doc")]
-async fn read_doc(_req: HttpRequest) -> impl Responder 
+async fn read_doc(_req: HttpRequest) -> impl Responder
 {
-    "미구현"
+    "unimplemented"
 }
 
 #[put("/api/update_doc")]
-async fn update_doc(_req: HttpRequest) -> impl Responder 
+async fn update_doc(_req: HttpRequest) -> impl Responder
 {
-    "미구현"
+    "unimplemented"
 }
 
 #[delete("/api/delete_doc")]
-async fn delete_doc(_req: HttpRequest) -> impl Responder 
+async fn delete_doc(_req: HttpRequest) -> impl Responder
 {
-    "미구현"
+    "unimplemented"
 }


### PR DESCRIPTION
- Fix `Cargo.toml` parsing error
  - 'alpha' causes error in package version
- Refactoring main and access_doc files

